### PR TITLE
Add task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,14 @@
+---
+name: Task
+about: Provide a concise description of a task
+title: "[TASK] -"
+labels: task
+assignees: ''
+
+---
+
+## Description
+Give a clear and concise description of what the task is.
+
+## Additional Context
+Enter any other details such as dependencies, environment, examples, etc.


### PR DESCRIPTION
Add a task template so that we can create tasks auto-labeled with task label instead of creating a blank issue.